### PR TITLE
INamingConvention.AttributeName addition allowing customization of a configuration element's attribute naming.

### DIFF
--- a/SimpleConfigSections/BasicExtensions/BasicExtensions.cs
+++ b/SimpleConfigSections/BasicExtensions/BasicExtensions.cs
@@ -13,6 +13,15 @@ namespace SimpleConfigSections.BasicExtensions
             return methodInfo.Name.Substring(4);
         }
 
+        public static PropertyInfo GetPropertyInfo(this MethodInfo method)
+        {
+            if (!method.IsSpecialName) return null;
+
+            var type = method.DeclaringType;
+
+            return type.GetProperty(method.Name.Substring(4), BindingFlags.Instance | BindingFlags.Public);
+        }
+
         internal static void Each<T>(this IEnumerable<T> sequence, Action<T> job)
         {
             foreach (var obj in sequence)

--- a/SimpleConfigSections/ConcreteConfiguration.cs
+++ b/SimpleConfigSections/ConcreteConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Castle.DynamicProxy;
 using SimpleConfigSections.BasicExtensions;
@@ -23,7 +24,11 @@ namespace SimpleConfigSections
                 invocation.Method.HasAttribute<CompilerGeneratedAttribute>()
                 )
             {
-                object obj = _configValue.Value(invocation.Method.PropertyName());
+                var propertyInfo = invocation.Method.GetPropertyInfo();
+                var name = propertyInfo == null ?
+                    invocation.Method.PropertyName()
+                    : NamingConvention.Current.AttributeName(propertyInfo);
+                object obj = _configValue.Value(name);
                 invocation.ReturnValue = obj;
             } else
             {

--- a/SimpleConfigSections/ConfigurationPropertyFactory.cs
+++ b/SimpleConfigSections/ConfigurationPropertyFactory.cs
@@ -60,10 +60,11 @@ namespace SimpleConfigSections
 
         private ConfigurationProperty NewConfigurationProperty(PropertyInfo pi, Type elementType)
         {
+            var name = NamingConvention.Current.AttributeName(pi);
             var options = GetOptions(pi);
             var defaultValue = GetDefaultValue(pi);
             var validator = GetValidator(pi);            
-            var configurationProperty = new ConfigurationProperty(pi.Name, elementType, defaultValue, TypeDescriptor.GetConverter(elementType), validator, options);            
+            var configurationProperty = new ConfigurationProperty(name, elementType, defaultValue, TypeDescriptor.GetConverter(elementType), validator, options);            
             return configurationProperty;
         }
 
@@ -85,6 +86,15 @@ namespace SimpleConfigSections
             if (defaultAttribute != null)
             {
                 defaultValue = defaultAttribute.Default();
+            }
+            
+            if (defaultValue == null)
+            {
+                var attribute = member.GetAttribute<DefaultValueAttribute>();
+                if (attribute != null)
+                {
+                    defaultValue = attribute.Value;
+                }
             }
             return defaultValue;
         }

--- a/SimpleConfigSections/INamingConvention.cs
+++ b/SimpleConfigSections/INamingConvention.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 
 namespace SimpleConfigSections
 {
@@ -11,5 +12,6 @@ namespace SimpleConfigSections
         string ClearCollectionElementName(Type collectionElementType, string propertyName);
         string SectionNameByIntefaceOrClassType(Type classOrInterface);
         string SectionNameByClassType(Type classOrInterface);
+        string AttributeName(PropertyInfo propertyInfo);
     }
 }

--- a/SimpleConfigSections/NamingConvention.cs
+++ b/SimpleConfigSections/NamingConvention.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using SimpleConfigSections.BasicExtensions;
 
 namespace SimpleConfigSections
@@ -71,6 +72,11 @@ namespace SimpleConfigSections
             return "clear";
         }
 
+        public virtual string AttributeName(PropertyInfo propertyInfo)
+        {
+            return propertyInfo.Name;
+        }
+
         private class CheckForInvalidNamesDecorator : INamingConvention
         {
             private readonly INamingConvention _realConvention;
@@ -123,6 +129,11 @@ namespace SimpleConfigSections
                 return
                     IfEmptyStringThenDefault(
                         conv => conv.SectionNameByIntefaceTypeAndPropertyName(propertyType, propertyName));
+            }
+
+            public string AttributeName(PropertyInfo propertyInfo)
+            {
+                return IfEmptyStringThenDefault(conv => conv.AttributeName(propertyInfo));
             }
 
             private string IfEmptyStringThenDefault(Func<INamingConvention, string> convention)

--- a/Tests.SimpleConfigSections/App.config
+++ b/Tests.SimpleConfigSections/App.config
@@ -55,17 +55,17 @@
   </PerformanceSection>
 
 
-  <PublishableConcepts >
+  <PublishableConcepts>
     <Concepts>
-      <Concept UniqueId="first" />
+      <Concept UniqueId="first"/>
     </Concepts>
     <Volumes>
-      <Volume Matcher="kot" />
+      <Volume Matcher="kot"/>
     </Volumes>
   </PublishableConcepts>
 
-  <SimpleConfiguration Name="SimpleName" Count="42" Matcher="123abc456" >
-    <Child Name="SimpleChild" />
+  <SimpleConfiguration name="SimpleName" Count="42" Matcher="123abc456">
+    <Child name="SimpleChild"/>
   </SimpleConfiguration>
   
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>

--- a/Tests.SimpleConfigSections/ConfigurationSectionBasedOnClassSpecs.cs
+++ b/Tests.SimpleConfigSections/ConfigurationSectionBasedOnClassSpecs.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using Machine.Specifications;
 using SimpleConfigSections;
@@ -8,8 +10,12 @@ namespace Tests.SimpleConfigSections
 {
     public class when_reading_configuration_section_defined_as_class
     {
-        private Because b =
-            () => section = Configuration.Get<SimpleConfiguration>();
+		private Because b =
+			() =>
+			{
+				Configuration.WithNamingConvention(new GetNameFromDisplayConvention());
+				section = Configuration.Get<SimpleConfiguration>();
+			};
 
         private It should_return_not_empty_configuration =
             () => section.ShouldNotBeNull();
@@ -59,6 +65,7 @@ namespace Tests.SimpleConfigSections
 
     public class SimpleConfiguration
     {
+		[Display(Name = "name")]
         public virtual string Name { get; set; }
         public virtual int Count { get; set; }
 
@@ -76,6 +83,21 @@ namespace Tests.SimpleConfigSections
             get { return NameAndCount; }
         }
     }
+
+	public class GetNameFromDisplayConvention : NamingConvention
+	{
+		public override string AttributeName(PropertyInfo propertyInfo)
+		{
+			var attr = propertyInfo.GetCustomAttribute<DisplayAttribute>();
+
+			if (attr != null && !string.IsNullOrEmpty(attr.Name))
+			{
+				return attr.Name;
+			}
+
+			return base.AttributeName(propertyInfo);
+		}
+	}
 
     public class SimpleConfigurationSection : ConfigurationSection<SimpleConfiguration>
     {

--- a/Tests.SimpleConfigSections/ConfigurationSectionBasedOnClassSpecs.cs
+++ b/Tests.SimpleConfigSections/ConfigurationSectionBasedOnClassSpecs.cs
@@ -88,7 +88,7 @@ namespace Tests.SimpleConfigSections
 	{
 		public override string AttributeName(PropertyInfo propertyInfo)
 		{
-			var attr = propertyInfo.GetCustomAttribute<DisplayAttribute>();
+			var attr = propertyInfo.GetCustomAttribute(typeof(DisplayAttribute)) as DisplayAttribute;
 
 			if (attr != null && !string.IsNullOrEmpty(attr.Name))
 			{

--- a/Tests.SimpleConfigSections/ConfigurationSectionBasedOnClassSpecs.cs
+++ b/Tests.SimpleConfigSections/ConfigurationSectionBasedOnClassSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Machine.Specifications;
@@ -88,7 +89,7 @@ namespace Tests.SimpleConfigSections
 	{
 		public override string AttributeName(PropertyInfo propertyInfo)
 		{
-			var attr = propertyInfo.GetCustomAttribute(typeof(DisplayAttribute)) as DisplayAttribute;
+			var attr = propertyInfo.GetCustomAttributes(false).OfType<DisplayAttribute>().SingleOrDefault();
 
 			if (attr != null && !string.IsNullOrEmpty(attr.Name))
 			{

--- a/Tests.SimpleConfigSections/ConfigurationsAttributeSpecs.cs
+++ b/Tests.SimpleConfigSections/ConfigurationsAttributeSpecs.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Configuration;
 using Machine.Specifications;
@@ -38,7 +39,7 @@ namespace Tests.SimpleConfigSections
         [Default(DefaultValue = "default attribute")]
         string DefaultStandardAttribute { get; set; }
 
-        [Default(DefaultValue = "should be overrided")]
+        [DefaultValue("should be overrided")]
         string SettedInConfig { get; set; }
         
     }


### PR DESCRIPTION
Added a new AttributeName method to INamingConventions allowing finer control over configuration element's attributes, along with handling of Sys.ComponentModel.DefaultValueAttribute
