### PR TITLE
Configuration cannot be loaded if interface name contains multiple leading 'I'

### DIFF
--- a/SimpleConfigSections/NamingConvention.cs
+++ b/SimpleConfigSections/NamingConvention.cs
@@ -49,10 +49,11 @@ namespace SimpleConfigSections
 
         public virtual string SectionNameByIntefaceType(Type interfaceType)
         {
-            return interfaceType.Name.TrimStart(new[]
-                                                    {
-                                                        'I'
-                                                    });
+            if (interfaceType.Name[0] == 'I')
+            {
+                return interfaceType.Name.Substring(1);
+            }
+            return interfaceType.Name;
         }
 
         public virtual string SectionNameByIntefaceTypeAndPropertyName(Type propertyType, string propertyName)


### PR DESCRIPTION
Hi,

If interface name for config section is smth like `IInterface`, configuration cannot be loaded with the error that class with name `nterface` cannot be found.

The issue is that naming convention trims all leading `I`, while it should only trim the first one.